### PR TITLE
Now default trust summaries

### DIFF
--- a/vignettes/data/MetaWards/JASMINsetup/setupSLURM.R
+++ b/vignettes/data/MetaWards/JASMINsetup/setupSLURM.R
@@ -50,6 +50,10 @@ system(paste0("mkdir -p ", filedir, "inputs"))
 write_csv(inputs, paste0(filedir, "inputs/inputs.csv"))
 write_csv(parRanges, paste0(filedir, "inputs/parRanges.csv"))
 
+## copy trust / ward lookups to inputs folder
+system(paste0("cp ../inputs/trust19Lookup.csv ", filedir, "inputs/"))
+system(paste0("cp ../inputs/Ward19_Lookup.csv ", filedir, "inputs/"))
+
 ## this next part creates the script file to pass to SLURM
 
 ## extract data

--- a/vignettes/data/MetaWards/JASMINsummary/collateSum.R
+++ b/vignettes/data/MetaWards/JASMINsummary/collateSum.R
@@ -19,7 +19,7 @@ names(output) <- hashes
 output <- bind_rows(output, .id = "output")
 
 ## write table out
-write_csv(output, paste0(filedir, "raw_outputs/summaries_", id, ".csv"), col_names = TRUE, row_names = FALSE)
+write_csv(output, paste0(filedir, "raw_outputs/summaries_", id, ".csv"), col_names = TRUE)
 
 ## compress file
 system(paste0("bzip2 -zf ", filedir, "raw_outputs/summaries_", id, ".csv"))

--- a/vignettes/data/MetaWards/JASMINsummary/collateSum.R
+++ b/vignettes/data/MetaWards/JASMINsummary/collateSum.R
@@ -20,6 +20,9 @@ output <- bind_rows(output, .id = "output")
 
 ## write table out
 write_csv(output, paste0(filedir, "raw_outputs/summaries_", id, ".csv"), col_names = TRUE, row_names = FALSE)
+
+## compress file
+system(paste0("bzip2 -zf ", filedir, "raw_outputs/summaries_", id, ".csv"))
  
 print("Finished")
 

--- a/vignettes/data/MetaWards/JASMINsummary/createSum.R
+++ b/vignettes/data/MetaWards/JASMINsummary/createSum.R
@@ -106,8 +106,8 @@ output <- map(files, function(file, filedir, hash, lookup) {
        ## collate to trust
        output <- inner_join(output, TrustLookup, by = "ward") %>%
             group_by(week, trustId) %>%
-            summarise(Hprev_mn = sum(Hprev_mn), HD = sum(Hdeaths), CD = sum(Cdeaths)) %>%
-            select(week, trustId, Hprev_mn, HD, CD) %>%
+            summarise(Hprev_mn = sum(Hprev_mn), cumHD = sum(Hdeaths), cumCD = sum(Cdeaths)) %>%
+            select(week, trustId, Hprev_mn, cumHD, cumCD) %>%
             ungroup()
        print(head(output)) 
     


### PR DESCRIPTION
Hi Danny,

This makes your trust-level summaries the default. Made some minor amends to the code, just to make a touch more succinct. Have added in cumulative hospitalisations. Also amended the names of the outputs to make clearer what they are:

`cumH`, `Hprev_mn`, `cumHD` and `cumCD`

Can amend back if you prefer.

T